### PR TITLE
Fix JS TypeError when WebGL context is not defined.

### DIFF
--- a/pinky-web/src/main.rs
+++ b/pinky-web/src/main.rs
@@ -202,6 +202,11 @@ fn setup_webgl( canvas: &Element ) -> Value {
             }
         }
 
+        if( gl === null ) {
+            console.error( "WebGL rendering context not found." );
+            return null;
+        }
+
         var vertex_shader = gl.createShader( gl.VERTEX_SHADER );
         var fragment_shader = gl.createShader( gl.FRAGMENT_SHADER );
         gl.shaderSource( vertex_shader, @{VERTEX_SHADER} );


### PR DESCRIPTION
This addresses cases where WebGL is either broken or disabled.  The
error message on Chrome was a Cannot read property 'create'Shader' of
null TypeError, however, the cause of this error was the variable `gl`
being null after attempting to retrieve all valid WebGL rendering contexts.