### PR TITLE
Fixed silencing of square 1 channel when sweep is disabled

### DIFF
--- a/nes/src/virtual_apu.rs
+++ b/nes/src/virtual_apu.rs
@@ -505,7 +505,7 @@ impl ChannelSquare {
     }
 
     fn is_silent( &self ) -> bool {
-        !self.enabled || self.period < 8 || self.length_counter == 0 || self.frequency_generator_output() >= 0x7FF
+        !self.enabled || self.period < 8 || self.length_counter == 0 || (self.frequency_generator_enabled == true && self.frequency_generator_output() >= 0x7FF)
     }
 
     fn output( &self ) -> u8 {


### PR DESCRIPTION
When the sweep is disabled, but the negate flag is set (%00001000 written to $4001), the `frequency_generator_output()` function shouldn't be called. In fact, because the last 3 bits are set to 0, the `adjust_period_based_on_frequency_generator()` function doesn't end up calling it.

But, it's being called to check if the square channel should be silenced:
`!self.enabled || self.period < 8 || self.length_counter == 0 || self.frequency_generator_output() >= 0x7FF`

When `frequency_generator_output()` is called here (with the sweep disabled), self.period is shifted by 0 bits, so period_delta = self.period.
Thus `self.period.wrapping_sub( period_delta ).wrapping_sub( 1 )` = (0-1), underflowing to 0xFFFF which is indeed greater than 0x7FF. So the channel is silenced.

Added an additional check to see if the sweep is enabled before checking its state.