### PR TITLE
Fix silencing of noise channel when envelope decay is on

### DIFF
--- a/nes/src/virtual_apu.rs
+++ b/nes/src/virtual_apu.rs
@@ -741,6 +741,10 @@ impl ChannelNoise {
         }
     }
 
+    fn clock_volume_generator( &mut self ) {
+        self.volume_generator.clock();
+    }
+
     fn clock_timer( &mut self ) {
         if self.timer == 0 {
             let bit_a = self.feedback_register.get_bits( 0b00000001 );
@@ -1011,6 +1015,7 @@ trait Private: Sized + Context {
             if entry.clk_volume_generator() {
                 self.state_mut().channel_square_1.clock_volume_generator();
                 self.state_mut().channel_square_2.clock_volume_generator();
+                self.state_mut().channel_noise.clock_volume_generator();
             }
 
             if entry.clk_length_counter() {

--- a/nes/src/virtual_apu.rs
+++ b/nes/src/virtual_apu.rs
@@ -505,7 +505,7 @@ impl ChannelSquare {
     }
 
     fn is_silent( &self ) -> bool {
-        !self.enabled || self.period < 8 || self.length_counter == 0 || self.frequency_generator_output() >= 0x7FF
+        !self.enabled || self.period < 8 || self.length_counter == 0 || (self.frequency_generator_enabled == true && self.frequency_generator_output() >= 0x7FF)
     }
 
     fn output( &self ) -> u8 {


### PR DESCRIPTION
The noise channel is silent any time the envelope decay bit (i.e. bit 4 of $400C) is set to 0.

When bit 4 is 0, the envelope decay is disabled, so `is_manually_controlled` is set to false, and thus the volume of the noise channel gets set to `self.generated_volume` in VolumeGenerator's `volume()` function.
The problem is, `self.generated_volume` is never updated, and so it stays at the default volume of 0, silencing the channel.

As far as I can tell, the noise channel is supposed to work exactly the same as the square channels when it comes to the volume register (apart from duty bits), so my proposed fix is to duplicate the function used to update the square channels' volume generator, and update the noise channel along with the squares in `clock_sequencer()`.